### PR TITLE
Update index.css

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -113,7 +113,7 @@
 .mentions__control {
     position: relative;
     z-index: 0;
-    display: table;
+    display: inline-flex;
     border-collapse: separate;
     width: 100%;
     max-width: 100%;


### PR DESCRIPTION
.mentions__control children overflows the parent width. Changing the display from table to inline-flex solves the issue.