### PR TITLE
Disable preload option added

### DIFF
--- a/src/CommentsDrawerLink.jsx
+++ b/src/CommentsDrawerLink.jsx
@@ -42,6 +42,10 @@ export default class _CommentsDrawerLink extends React.Component {
         <i className="fa fa-times" aria-hidden="true"></i>&nbsp;Close
       </button>
     </div>);
+    let comments
+    if(!this.props.disablePreload || this.state.commentsDrawerOpen){
+      comments = <Comments {...this.props} commentCountRefreshed={this.updateCommentCount.bind(this)}/>
+    }
 
     return (
       <span>
@@ -59,7 +63,7 @@ export default class _CommentsDrawerLink extends React.Component {
           position={this.props.position === 'left' ? 'left' : 'right'}
           closeOnClickOutside={true}
           footer={this.props.footer ? this.props.footer : footer}>
-        <Comments {...this.props} commentCountRefreshed={this.updateCommentCount.bind(this)}/>
+        {comments}
         </Drawer>
       </span>
     );
@@ -75,5 +79,6 @@ _CommentsDrawerLink.propTypes = {
   position: PropTypes.string,
   header: PropTypes.node,
   footer: PropTypes.node,
-  opened: PropTypes.bool
+  opened: PropTypes.bool,
+  disablePreload: PropTypes.bool
 };

--- a/stories/index.js
+++ b/stories/index.js
@@ -15,5 +15,6 @@ storiesOf('Mention box', module)
   .add('Highlighter for mentions', () => (<Comments accessToken={"ff294991-6ec1-4219-b868-3dcfa726b045"} resourceUri={"http://eda234a4-485f-4c0c-806d-1c9748994c00.com/non-existent"} newestFirst={true} initialValue={"@[John Doe](b636a568-b51e-4653-903c-01e7bd5a5086)\n check for displaced highlighter - @[John Does](b636a568-b51e-4653-903c-01e71d5a5a86)"}/>));
 
 storiesOf('Comments drawer with link', module)
-  .add('Link alone', () => (<CommentsDrawerLink accessToken={"51d3ab44-efe1-4cc7-b0fa-6c86fa2ca134"} resourceUri={"http://eda234a4-485f-4c0c-806d-1c9748994c00.com"} newestFirst={true} />))
-  .add('Link and drawer open by default', () => (<CommentsDrawerLink accessToken={"51d3ab44-efe1-4cc7-b0fa-6c86fa2ca134"} resourceUri={"http://eda234a4-485f-4c0c-806d-1c9748994c00.com"} newestFirst={true} opened={true}/>));
+.add('Link alone', () => (<CommentsDrawerLink accessToken={"51d3ab44-efe1-4cc7-b0fa-6c86fa2ca134"} resourceUri={"http://eda234a4-485f-4c0c-806d-1c9748994c00.com"} newestFirst={true} />))
+.add('Preload disabled', () => (<CommentsDrawerLink accessToken={"51d3ab44-efe1-4cc7-b0fa-6c86fa2ca134"} resourceUri={"http://eda234a4-485f-4c0c-806d-1c9748994c00.com"} newestFirst={true} disablePreload refreshInterval={1}/>))
+.add('Link and drawer open by default', () => (<CommentsDrawerLink accessToken={"51d3ab44-efe1-4cc7-b0fa-6c86fa2ca134"} resourceUri={"http://eda234a4-485f-4c0c-806d-1c9748994c00.com"} newestFirst={true} opened={true}/>));


### PR DESCRIPTION
disablePreload option added to the drawer component.

This option disable the preload of comments of the drawer component.

Once the drawer is opened, the comments will be loaded and the red badge with the count of comments will be updated.