### PR TITLE
Provides a small addition to suggestions, listing the user's email

### DIFF
--- a/mocks/auth/access-management/v1/principals/GET.mock
+++ b/mocks/auth/access-management/v1/principals/GET.mock
@@ -6,23 +6,28 @@ Access-Control-Allow-Origin: *
     "principals" : [
         {
             "name" : "John Doe",
-            "user_id" : "49c087ab-3fee-4994-86e7-c63d2b47ac8b"
+            "user_id" : "49c087ab-3fee-4994-86e7-c63d2b47ac8b",
+            "email": "john_doe@cimpress.com"
         },
         {
             "name" : "John Does",
-            "user_id" : "97b54b76-60d0-498f-b123-7cb9e1020eb4"
+            "user_id" : "97b54b76-60d0-498f-b123-7cb9e1020eb4",
+            "email": "john_does@cimpress.com"
         },
         {
             "name" : "George Washington",
-            "user_id": "20fee9d7-3e84-4fdb-98ee-452099393f19"
+            "user_id": "20fee9d7-3e84-4fdb-98ee-452099393f19",
+            "email": "george_washington@cimpress.com"
         },
         {
             "name" : "John Adams",
-            "user_id": "8b4560c2-3a4f-4c5d-8215-3a8351c76ceb"
+            "user_id": "8b4560c2-3a4f-4c5d-8215-3a8351c76ceb",
+            "email": "john_adams@cimpress.com"
         },
         {
             "name" : "Thomas Jefferson",
-            "user_id": "4c2028c2-acec-401d-916e-c5b448b056c6"
+            "user_id": "4c2028c2-acec-401d-916e-c5b448b056c6",
+            "email": "thomas_jefferson@cimpress.com"
         }
     ]
 }

--- a/src/Comments.jsx
+++ b/src/Comments.jsx
@@ -251,6 +251,14 @@ class _Comments extends React.Component {
                      commentVisibilityLevels={this.state.commentVisibilityLevels}/>));
     }
 
+    renderSuggestion(entry, search, highlightedDisplay, index) {
+      return (
+        <span>
+          {highlightedDisplay} <i><small>{entry.email}</small></i>
+        </span>
+        )
+    }
+
     render() {
         let comments = null;
 
@@ -285,6 +293,7 @@ class _Comments extends React.Component {
                                  data={(search, callback) => {
                                      this.mentionsClient.fetchMatchingMentions(search).then(callback)
                                  }}
+                                 renderSuggestion={this.renderSuggestion}
                         />
                     </MentionsInput>
                 </div>

--- a/src/clients/MentionsClient.js
+++ b/src/clients/MentionsClient.js
@@ -20,7 +20,7 @@ export default class MentionsClient extends FetchClient {
             .then(response => {
                 if ( response.status === 200 ) {
                     return response.json().then(responseJson => responseJson.principals.map(p => {
-                        return {id: p.user_id, display: p.name};
+                        return {id: p.user_id, display: p.name, email: p.email};
                     }));
                 } else {
                     throw new Error(`Unable to fetch principals for query: ${query}`);


### PR DESCRIPTION
To cover cases where there are multiple users with same name but different email address, the suggestions should list the email address

<img width="432" alt="screen shot 2018-06-19 at 22 27 04" src="https://user-images.githubusercontent.com/5499225/41622482-ffe44996-740f-11e8-84a3-5ffa1b3060e8.png">
