### PR TITLE
Allow to edit comment to be an empty comment

### DIFF
--- a/src/Comment.jsx
+++ b/src/Comment.jsx
@@ -264,7 +264,8 @@ class _Comment extends React.Component {
 
         let commentBody = (
             <div style={{position: 'relative'}}>
-                <MentionsInput className={classes} value={this.state.editedComment || this.state.comment}
+                <MentionsInput className={classes}
+                    value={this.state.editedComment !== null ? this.state.editedComment : this.state.comment}
                     onChange={this.change.bind(this)}
                     displayTransform={(id, display, type) => `@${display}`} allowSpaceInQuery={true}
                     readOnly={classes.includes('disabled')}>

--- a/src/Comment.jsx
+++ b/src/Comment.jsx
@@ -239,7 +239,7 @@ class _Comment extends React.Component {
                 let cancelEdit = <div onClick={this.cancelEditing.bind(this)}
                     className={'fa fa-undo mentions-cancel'}/>;
                     editMenu = (<div>
-                        {(this.state.editedComment !== null && this.state.editedComment !== this.state.comment)
+                        {(this.state.editedComment !== null && this.state.editedComment !== this.state.comment && this.state.editedComment !== '')
                             ? completeEdit
                             : null}
                         {cancelEdit}


### PR DESCRIPTION
Currently it is not possible to edit comment and remove the body completely because whenever the new content is empty it is being replaces with original content.