### PR TITLE
We don't care why we can't fetch the settings

### DIFF
--- a/src/clients/CustomizrClient.js
+++ b/src/clients/CustomizrClient.js
@@ -20,13 +20,7 @@ export default class CustomizrClient extends FetchClient {
                 if (response.status === 200) {
                     return response.json();
                 }
-
-                // No settings stored - this is OK
-                if (response.status === 404) {
-                    return {}
-                }
-
-                throw new Error(`Unable to fetch user settings from Customizr`);
+                return {};
             });
     }
 


### PR DESCRIPTION
We don't care why we can't fetch the settings. If there is a problem while fetching the settings, we should fall back to some defaults and continue serving the user. Do the reasonable thing.

Should we do something about the error? Maybe log it. Maybe even that is not needed.