### PR TITLE
Pull canonical data from coam

### DIFF
--- a/src/clients/MentionsClient.js
+++ b/src/clients/MentionsClient.js
@@ -12,14 +12,15 @@ export default class MentionsClient extends _FetchClient {
             return Promise.resolve([]);
         }
 
-        let url = `https://api.cimpress.io/auth/access-management/v1/principals?q=${query}`;
+        let url = `https://api.cimpress.io/auth/access-management/v1/search/canonicalPrincipals/bySubstring?q=${query}`;
         let init = this.getDefaultConfig('GET');
 
         return fetch(url, init)
             .then((response) => {
                 if (response.status === 200) {
-                    return response.json().then((responseJson) => responseJson.principals.map((p) => {
-                        return {id: p.user_id, display: p.name, email: p.email};
+                    return response.json().then((responseJson) => responseJson.canonical_principals.map((p) => {
+                        const profile = p.profiles[0] || {};
+                        return {id: profile.user_id || p.canonical_principal, display: profile.name, email: p.canonical_principal};
                     }));
                 } else {
                     throw new Error(`Unable to fetch principals for query: ${query}`);


### PR DESCRIPTION
We were getting duplicates due to the diferent profiles of an email.
We are now calling the canonical principals so this list will become,
```
[
    vcuenagarcia92@gmail.com,
    Victor Cuena Garcia vcuenagarcia@cimpress.com
]
```

![image](https://user-images.githubusercontent.com/8748977/49448972-35a90280-f7da-11e8-8422-6fe13d285180.png)
