### PR TITLE
Add CommentIndicator component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-cimpress-comment",
-  "version": "2.0.1",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-cimpress-comment",
-  "version": "2.0.1",
+  "version": "2.2.0",
   "description": "Visualizes comment(s) for a particular platform resource",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/CommentIndicator.jsx
+++ b/src/CommentIndicator.jsx
@@ -3,15 +3,12 @@ import PropTypes from 'prop-types';
 
 import '../style/index.css';
 
-import {Alert, shapes, Tooltip} from '@cimpress/react-components';
+import {Tooltip} from '@cimpress/react-components';
 
 import CommentsClient from './clients/CommentsClient';
 
 import {getI18nInstance} from './tools/i18n';
 import {translate} from 'react-i18next';
-import {errorToString, getSubFromJWT} from './tools/helper';
-
-let {Spinner} = shapes;
 
 class CommentIndicator extends React.Component {
     constructor(props) {
@@ -73,8 +70,8 @@ class CommentIndicator extends React.Component {
     init() {
         clearInterval(this._refreshIntervalHandle);
         this._refreshIntervalHandle = setInterval(() => {
-          this.fetchCommentCount();
-          this.fetchUnreadCommentCount();
+            this.fetchCommentCount();
+            this.fetchUnreadCommentCount();
         }, Math.max((this.props.refreshInterval || 60) * 1000, 5000));
     }
 
@@ -89,7 +86,7 @@ class CommentIndicator extends React.Component {
             fetchingComments: true,
         }, () => client
             .fetchComments()
-            .then(({ responseJson }) => {
+            .then(({responseJson}) => {
                 this.safeSetState({
                     fetchingComments: false,
                     commentCount: responseJson.length,
@@ -100,7 +97,6 @@ class CommentIndicator extends React.Component {
             .catch((err) => {
                 this.safeSetState({
                     fetchingComments: false,
-                    error: err,
                     failedFetchingComments: true,
                     errorFetchingComments: err,
                 });
@@ -118,7 +114,7 @@ class CommentIndicator extends React.Component {
             fetchingUnreadComments: true,
         }, () => client
             .getUserInfo()
-            .then(({ unreadCount }) => {
+            .then(({unreadCount}) => {
                 this.safeSetState({
                     fetchingUnreadComments: false,
                     unreadCommentCount: unreadCount,
@@ -129,7 +125,6 @@ class CommentIndicator extends React.Component {
             .catch((err) => {
                 this.safeSetState({
                     fetchingUnreadComments: false,
-                    error: err,
                     failedFetchingUnreadComments: true,
                     errorFetchingUnreadComments: err,
                 });
@@ -137,13 +132,13 @@ class CommentIndicator extends React.Component {
     }
 
     onClick(e) {
-      e.preventDefault();
+        e.preventDefault();
 
-      if (this.props.onClick) {
-        this.props.onClick({
-          resourceUri: this.props.resourceUri
-        });
-      }
+        if (this.props.onClick) {
+            this.props.onClick({
+                resourceUri: this.props.resourceUri,
+            });
+        }
     }
 
     tt(key) {
@@ -156,8 +151,8 @@ class CommentIndicator extends React.Component {
         let errorDetails = error && error.message
             ? (<span>
                   Error details: <br/>
-                  {error.message}
-              </span>)
+                {error.message}
+            </span>)
             : null;
 
         let label = (
@@ -168,29 +163,29 @@ class CommentIndicator extends React.Component {
         );
 
         return (
-              <Tooltip
-                  direction="right"
-                  contents={label}
-                  className="rcc-tooltip-wide">
-                  {content}
-              </Tooltip>
+            <Tooltip
+                direction="right"
+                contents={label}
+                className="rcc-tooltip-wide">
+                {content}
+            </Tooltip>
         );
     }
 
     renderError(error) {
-            let content = (
-                <div className="comment-drawer-button">
-                    <span style={{ position: "absolute", color: "red" }} className="fa fa-times"/>
-                    <span className="fa fa-comments-o"/>
-                </div>
-            );
+        let content = (
+            <div className="comment-drawer-button">
+                <span style={{position: 'absolute', color: 'red'}} className="fa fa-times"/>
+                <span className="fa fa-comments-o"/>
+            </div>
+        );
 
-            return this.wrapInErrorTooltip(error, content);
+        return this.wrapInErrorTooltip(error, content);
     }
 
     render() {
         if (!this.props.resourceUri) {
-          return this.renderError(new Error(this.tt('incorrect_component_setup')));
+            return this.renderError(new Error(this.tt('incorrect_component_setup')));
         }
 
         if (this.failedFetching) {
@@ -234,13 +229,11 @@ CommentIndicator.propTypes = {
     refreshInterval: PropTypes.number,
 
     onClick: PropTypes.func,
-    addPadding: PropTypes.bool,
     hideWhenNoUnreadComments: PropTypes.bool,
 };
 
 CommentIndicator.defaultProps = {
     locale: 'eng',
-    addPadding: false,
     hideWhenNoUnreadComments: false,
 };
 

--- a/src/CommentIndicator.jsx
+++ b/src/CommentIndicator.jsx
@@ -139,8 +139,6 @@ class CommentIndicator extends React.Component {
     onClick(e) {
       e.preventDefault();
 
-      console.log(this.state);
-
       if (this.props.onClick) {
         this.props.onClick({
           resourceUri: this.props.resourceUri

--- a/src/CommentIndicator.jsx
+++ b/src/CommentIndicator.jsx
@@ -1,0 +1,249 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import '../style/index.css';
+
+import {Alert, shapes, Tooltip} from '@cimpress/react-components';
+
+import CommentsClient from './clients/CommentsClient';
+
+import {getI18nInstance} from './tools/i18n';
+import {translate} from 'react-i18next';
+import {errorToString, getSubFromJWT} from './tools/helper';
+
+let {Spinner} = shapes;
+
+class CommentIndicator extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            commentCount: 0,
+            unreadCommentCount: 0,
+            fetchingComments: false,
+            fetchingUnreadComments: false,
+            failedFetchingComments: false,
+            failedFetchingUnreadComments: false,
+            errorFetchingComments: null,
+            errorFetchingUnreadComments: null,
+        };
+    }
+
+    get hasComments() {
+        return this.state.commentCount > 0 || this.state.unreadCommentCount > 0;
+    }
+
+    get fetching() {
+        return this.state.fetchingComments || this.state.fetchingUnreadComments;
+    }
+
+    get failedFetching() {
+        return this.state.failedFetchingComments || this.state.failedFetchingUnreadComments;
+    }
+
+    get errorFetching() {
+        return this.state.errorFetchingComments || this.state.errorFetchingUnreadComments;
+    }
+
+    componentDidMount() {
+        this._ismounted = true;
+        this.init();
+        this.fetchCommentCount();
+        this.fetchUnreadCommentCount();
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.resourceUri !== prevProps.resourceUri || this.props.accessToken !== prevProps.accessToken) {
+            this.fetchCommentCount();
+            this.fetchUnreadCommentCount();
+        }
+    }
+
+    componentWillUnmount() {
+        this._ismounted = false;
+        clearInterval(this._refreshIntervalHandle);
+    }
+
+    safeSetState(data, callback) {
+        if (this._ismounted) {
+            this.setState(data, callback);
+        }
+    }
+
+    init() {
+        clearInterval(this._refreshIntervalHandle);
+        this._refreshIntervalHandle = setInterval(() => {
+          this.fetchCommentCount();
+          this.fetchUnreadCommentCount();
+        }, Math.max((this.props.refreshInterval || 60) * 1000, 5000));
+    }
+
+    fetchCommentCount() {
+        if (!this.props.accessToken) {
+            return;
+        }
+
+        let client = new CommentsClient(this.props.accessToken, this.props.resourceUri);
+
+        this.safeSetState({
+            fetchingComments: true,
+        }, () => client
+            .fetchComments()
+            .then(({ responseJson }) => {
+                this.safeSetState({
+                    fetchingComments: false,
+                    commentCount: responseJson.length,
+                    failedFetchingComments: false,
+                    errorFetchingComments: null,
+                });
+            })
+            .catch((err) => {
+                this.safeSetState({
+                    fetchingComments: false,
+                    error: err,
+                    failedFetchingComments: true,
+                    errorFetchingComments: err,
+                });
+            }));
+    }
+
+    fetchUnreadCommentCount() {
+        if (!this.props.accessToken) {
+            return;
+        }
+
+        let client = new CommentsClient(this.props.accessToken, this.props.resourceUri);
+
+        this.safeSetState({
+            fetchingUnreadComments: true,
+        }, () => client
+            .getUserInfo()
+            .then(({ unreadCount }) => {
+                this.safeSetState({
+                    fetchingUnreadComments: false,
+                    unreadCommentCount: unreadCount,
+                    failedFetchingUnreadComments: false,
+                    errorFetchingUnreadComments: null,
+                });
+            })
+            .catch((err) => {
+                this.safeSetState({
+                    fetchingUnreadComments: false,
+                    error: err,
+                    failedFetchingUnreadComments: true,
+                    errorFetchingUnreadComments: err,
+                });
+            }));
+    }
+
+    onClick(e) {
+      e.preventDefault();
+
+      console.log(this.state);
+
+      if (this.props.onClick) {
+        this.props.onClick({
+          resourceUri: this.props.resourceUri
+        });
+      }
+    }
+
+    tt(key) {
+        // eslint-disable-next-line react/prop-types
+        const {t, locale} = this.props;
+        return t(key, {lng: locale});
+    }
+
+    wrapInErrorTooltip(error, content) {
+        let errorDetails = error && error.message
+            ? (<span>
+                  Error details: <br/>
+                  {error.message}
+              </span>)
+            : null;
+
+        let label = (
+            <span>
+                {this.tt('unable_to_retrieve_comments')}<br/>
+                {errorDetails}
+            </span>
+        );
+
+        return (
+              <Tooltip
+                  direction="right"
+                  contents={label}
+                  className="rcc-tooltip-wide">
+                  {content}
+              </Tooltip>
+        );
+    }
+
+    renderError(error) {
+            let content = (
+                <div className="comment-drawer-button">
+                    <span style={{ position: "absolute", color: "red" }} className="fa fa-times"/>
+                    <span className="fa fa-comments-o"/>
+                </div>
+            );
+
+            return this.wrapInErrorTooltip(error, content);
+    }
+
+    render() {
+        if (!this.props.resourceUri) {
+          return this.renderError(new Error(this.tt('incorrect_component_setup')));
+        }
+
+        if (this.failedFetching) {
+            return this.renderError(this.errorFetching);
+        }
+
+        if (!this.hasComments || (this.props.hideWhenNoUnreadComments && this.state.unreadCommentCount === 0)) {
+            return null;
+        }
+
+        let items = null;
+        if (this.fetching) {
+            items = <i className={'fa fa-spinner fa-spin'}/>;
+        } else if (this.state.unreadCommentCount > 0) {
+            items = this.state.unreadCommentCount;
+        }
+
+        let badge = items
+            ? (
+                <span className={`comment-count-badge ${this.state.fetchingData ? 'comment-count-badge-loading' : ''}`}>
+                    {items}
+                </span>
+            )
+            : null;
+
+
+        return (
+            <div className="comment-indicator">
+                <span className="fa fa-comments-o" onClick={this.onClick.bind(this)}/>
+                {badge}
+            </div>
+        );
+    }
+}
+
+CommentIndicator.propTypes = {
+    locale: PropTypes.string,
+    accessToken: PropTypes.string.isRequired,
+    resourceUri: PropTypes.string.isRequired,
+
+    refreshInterval: PropTypes.number,
+
+    onClick: PropTypes.func,
+    addPadding: PropTypes.bool,
+    hideWhenNoUnreadComments: PropTypes.bool,
+};
+
+CommentIndicator.defaultProps = {
+    locale: 'eng',
+    addPadding: false,
+    hideWhenNoUnreadComments: false,
+};
+
+export default translate('translations', {i18n: getI18nInstance()})(CommentIndicator);

--- a/src/CommentIndicator.jsx
+++ b/src/CommentIndicator.jsx
@@ -192,7 +192,7 @@ class CommentIndicator extends React.Component {
             return this.renderError(this.errorFetching);
         }
 
-        if (!this.hasComments || (this.props.hideWhenNoUnreadComments && this.state.unreadCommentCount === 0)) {
+        if (!this.hasComments) {
             return null;
         }
 
@@ -228,13 +228,11 @@ CommentIndicator.propTypes = {
 
     refreshInterval: PropTypes.number,
 
-    onClick: PropTypes.func,
-    hideWhenNoUnreadComments: PropTypes.bool,
+    onClick: PropTypes.func
 };
 
 CommentIndicator.defaultProps = {
     locale: 'eng',
-    hideWhenNoUnreadComments: false,
 };
 
 export default translate('translations', {i18n: getI18nInstance()})(CommentIndicator);

--- a/src/CommentIndicator.jsx
+++ b/src/CommentIndicator.jsx
@@ -188,10 +188,6 @@ class CommentIndicator extends React.Component {
             return this.renderError(new Error(this.tt('incorrect_component_setup')));
         }
 
-        if (this.failedFetching) {
-            return this.renderError(this.errorFetching);
-        }
-
         if (!this.hasComments) {
             return null;
         }

--- a/src/CommentIndicator.jsx
+++ b/src/CommentIndicator.jsx
@@ -224,7 +224,7 @@ CommentIndicator.propTypes = {
 
     refreshInterval: PropTypes.number,
 
-    onClick: PropTypes.func
+    onClick: PropTypes.func,
 };
 
 CommentIndicator.defaultProps = {

--- a/src/Comments.jsx
+++ b/src/Comments.jsx
@@ -51,7 +51,7 @@ class Comments extends React.Component {
         if (this.props.accessToken !== prevProps.accessToken) {
             this.jwtSub = getSubFromJWT(this.props.accessToken);
         }
-        if (this.props.resourceUri !== prevProps.resourceUri || this.props.newestFirst !== prevProps.newestFirst) {
+        if (this.props.resourceUri !== prevProps.resourceUri || this.props.newestFirst !== prevProps.newestFirst || this.props.accessToken !== prevProps.accessToken) {
             this.commentsClient = new CommentsClient(this.props.accessToken, this.props.resourceUri);
             this.fetchComments();
         }

--- a/src/CommentsDrawerLink.jsx
+++ b/src/CommentsDrawerLink.jsx
@@ -69,7 +69,7 @@ class CommentsDrawerLink extends React.Component {
     }
 
     componentDidUpdate(prevProps) {
-        if (prevProps.resourceUri !== this.props.resourceUri) {
+        if (this.props.resourceUri !== prevProps.resourceUri || this.props.accessToken !== prevProps.accessToken) {
             this.fetchUnreadCount();
         }
         if (prevProps.opened !== this.props.opened) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import _Comments from './Comments';
 import _CommentsDrawerLink from './CommentsDrawerLink';
 import _CommentChat from './CommentChat';
+import _CommentIndicator from './CommentIndicator';
 
 export class Comments extends _Comments {
 
@@ -11,6 +12,10 @@ export class CommentsDrawerLink extends _CommentsDrawerLink {
 }
 
 export class CommentChat extends _CommentChat {
+
+}
+
+export class CommentIndicator extends _CommentIndicator {
 
 }
 

--- a/stories/development/stories.js
+++ b/stories/development/stories.js
@@ -80,7 +80,7 @@ storiesOf('Production-like', module)
                         locale={text('locale', null, 'eng')}
                         accessToken={auth.getAccessToken()}
                         resourceUri={text('resourceUri', 'https://stereotype.trdlnk.cimpress.io/v1/templates/123123', 'Settings')}
-                        onClick={(data) => alert(JSON.stringify(data, null, 4))}
+                        onClick={(data) => alert(`Callback called with value: ${JSON.stringify(data, null, 4)}`)}
                         refreshInterval={5}
                         hideWhenNoUnreadComments={boolean('hideWhenNoUnreadComments', false)}
                     />

--- a/stories/development/stories.js
+++ b/stories/development/stories.js
@@ -7,6 +7,7 @@ import auth from './auth';
 import Comments from '../../src/Comments';
 import CommentsDrawerLink from '../../src/CommentsDrawerLink';
 import CommentChat from '../../src/CommentChat';
+import CommentIndicator from '../../src/CommentIndicator';
 
 storiesOf('Production-like', module)
     .addDecorator(withKnobs)
@@ -63,6 +64,25 @@ storiesOf('Production-like', module)
                             left: 'left',
                             right: 'right',
                         }, 'left')}
+                    />
+                </div>
+            </div>
+        </Authenticated>;
+    })
+    .add('CommentIndicator', () => {
+        return <Authenticated>
+            <div className={'card'}>
+                <p>
+                    Note: depending on props passed, the component below may not render if there are no comments or no unread comments on the resource. If you expected it to be there, try watching a different <em>resourceUri</em> or fiddling with props.
+                </p>
+                <div className={'card-block'}>
+                    <CommentIndicator
+                        locale={text('locale', null, 'eng')}
+                        accessToken={auth.getAccessToken()}
+                        resourceUri={text('resourceUri', 'https://stereotype.trdlnk.cimpress.io/v1/templates/123123', 'Settings')}
+                        onClick={() => console.log("ow")}
+                        refreshInterval={5}
+                        hideWhenNoUnreadComments={boolean('hideWhenNoUnreadComments', false)}
                     />
                 </div>
             </div>

--- a/stories/development/stories.js
+++ b/stories/development/stories.js
@@ -80,7 +80,7 @@ storiesOf('Production-like', module)
                         locale={text('locale', null, 'eng')}
                         accessToken={auth.getAccessToken()}
                         resourceUri={text('resourceUri', 'https://stereotype.trdlnk.cimpress.io/v1/templates/123123', 'Settings')}
-                        onClick={() => console.log("ow")}
+                        onClick={(data) => alert(JSON.stringify(data, null, 4))}
                         refreshInterval={5}
                         hideWhenNoUnreadComments={boolean('hideWhenNoUnreadComments', false)}
                     />

--- a/stories/ui-tests/stories.js
+++ b/stories/ui-tests/stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {storiesOf} from '@storybook/react';
 import Comments from '../../src/Comments';
 import CommentsDrawerLink from '../../src/CommentsDrawerLink';
+import CommentIndicator from '../../src/CommentIndicator';
 
 import {mockCustomizer} from './mockCustomizr';
 import {mockCoamPrincipals} from './mockCoam';
@@ -94,8 +95,25 @@ storiesOf('Comments drawer with link', module)
         </div>;
     });
 
+storiesOf('Comment indicator', module)
+    .add('with items', () => {
+        initMock();
+        return <div className={'card'}>
+            <p>
+                Note: depending on props passed, the component below may not render if there are no comments or no unread comments on the resource. If you expected it to be there, try watching a different <em>resourceUri</em> or fiddling with props.
+            </p>
+            <div className={'card-block'}>
+                <CommentIndicator
+                    accessToken={'51d3ab44-efe1-4cc7-b0fa-6c86fa2ca134'}
+                    resourceUri={'http://eda234a4-485f-4c0c-806d-1c9748994c00.com'}
+                    onClick={(data) => alert(`Callback called with value: ${JSON.stringify(data, null, 4)}`)}
+                    hideWhenNoUnreadComments={false} />
+            </div>
+            </div>;
+    });
+
 storiesOf('Errors', module)
-    .add('With get comments returning 403', () => {
+    .add('Comments - With get comments returning 403', () => {
         initMock()
             .get('https://comment.trdlnk.cimpress.io/v0/resources?uri=http%3A%2F%2Feda234a4-485f-4c0c-806d-1c9748994c00.com%2F403', {
                 status: 403,

--- a/stories/ui-tests/stories.js
+++ b/stories/ui-tests/stories.js
@@ -113,7 +113,7 @@ storiesOf('Comment indicator', module)
     });
 
 storiesOf('Errors', module)
-    .add('Comments - With get comments returning 403', () => {
+    .add('With get comments returning 403', () => {
         initMock()
             .get('https://comment.trdlnk.cimpress.io/v0/resources?uri=http%3A%2F%2Feda234a4-485f-4c0c-806d-1c9748994c00.com%2F403', {
                 status: 403,

--- a/style/index.css
+++ b/style/index.css
@@ -84,6 +84,14 @@
     color: #0088a9 !important;
 }
 
+.comment-indicator {
+    font-size: 2em;
+    color: #0088a9;
+    cursor: pointer;
+    position: relative;
+    display: inline-block;
+}
+
 .comment-drawer-button {
     font-size: 2em;
     color: #0088a9;


### PR DESCRIPTION
A new React component is available: CommentIndicator. It visually resembles CommentsDrawerLink, but instead of opening the comment drawer upon clicking the speech bubble icon, a custom onClick callback is called with resourceUri as one of the returned keys.

![Screenshot from 2019-06-30 17-32-49](https://user-images.githubusercontent.com/10243844/60398838-1bab8480-9b5d-11e9-8c26-a03e53e06c36.png)

### Visuals:
If the resource has no comments on it, nothing is rendered.

If the resource has some comments on it, but all have been read, the speech bubble icon is displayed. Note: there is a prop hideWhenNoUnreadComments which, if set to true, overrides this behaviour, hiding the bubble.

![Screenshot from 2019-06-30 17-26-27](https://user-images.githubusercontent.com/10243844/60398777-958f3e00-9b5c-11e9-9340-53680a76dc4e.png)

If the resource has some unread comments on it, a speech bubble icon with the number of unread comments in a badge is shown.

![Screenshot from 2019-06-30 17-31-11](https://user-images.githubusercontent.com/10243844/60398814-e3a44180-9b5c-11e9-97e6-a8125001f6ce.png)

If the component is fetching data, the badge has a spinner inside.

![Screenshot from 2019-06-30 17-26-24](https://user-images.githubusercontent.com/10243844/60398781-9c1db580-9b5c-11e9-8272-be82495302c6.png)

If the component encounters an error while fetching or is configured incorrectly, the speech bubble icon is crossed. Upon hovering, a tooltip displays the error.

![image](https://user-images.githubusercontent.com/10243844/60398762-7a243300-9b5c-11e9-9834-9744c33c1984.png)