### PR TITLE
Ensure name fields are fetched again on prop update

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
-#
+
+## [2.2.5] - 2019-08-07
+### Fixed
+- Fix updatedByName and createdByName in `CommentAuthor`, `CommentTime` not re-fetched on prop change
+
 ## [2.2.4] - 2019-08-06
 ### Fixed
 - Fix infinite rendering loop caused by unchecked componentDidUpdate() in `CommentAuthor`, `CommentTime`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-cimpress-comment",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-cimpress-comment",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Visualizes comment(s) for a particular platform resource",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/components/CommentAuthor.jsx
+++ b/src/components/CommentAuthor.jsx
@@ -41,7 +41,7 @@ class CommentAuthor extends React.Component {
     }
 
     fetchCreatedByName() {
-        if (!this.state.createdByName && this.props.createdBy) {
+        if (this.props.createdBy) {
             getPrincipalMemoized(this.props.accessToken, this.props.createdBy)
                 .then((responseJson) => {
                     if (responseJson && responseJson.profile && responseJson.profile.name) {

--- a/src/components/CommentTime.jsx
+++ b/src/components/CommentTime.jsx
@@ -37,14 +37,13 @@ class CommentTime extends React.Component {
     componentDidUpdate(prevProps) {
         if (this.props.accessToken
             && (prevProps.accessToken !== this.props.accessToken
-                || prevProps.createdBy !== this.props.createdBy
                 || prevProps.updatedBy !== this.props.updatedBy)) {
             this.fetchUpdatedByName();
         }
     }
 
     fetchUpdatedByName() {
-        if (!this.state.updatedByName && this.props.updatedBy) {
+        if (this.props.updatedBy) {
             getPrincipalMemoized(this.props.accessToken, this.props.updatedBy)
                 .then((responseJson) => {
                     if (responseJson && responseJson.profile && responseJson.profile.name) {


### PR DESCRIPTION
A refactor in #121 has carried over a bug where prop changes would not cause names to be re-fetched.